### PR TITLE
[bugfix] Elements bounds non-window containers 

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -20,6 +20,12 @@
         <button onclick="verticalPanePosObserver.activate()">Activate</button>
       </h3>
       <div class="dummyContent"></div>
+      <div id="elementInVerticalPane" class="block">
+        <h3>Element</h3>
+        <button onclick="elementInVerticalPaneObserver.destroy()">Destroy</button>
+        <button onclick="elementInVerticalPaneObserver.activate()">Activate</button>
+      </div>
+      <div class="dummyContent"></div>
     </div>
 
     <div id="horizontalPane">
@@ -28,6 +34,12 @@
         <button onclick="horizontalPanePosObserver.destroy()">Destroy</button>
         <button onclick="horizontalPanePosObserver.activate()">Activate</button>
       </h3>
+      <div class="dummyContent"></div>
+      <div id="elementInHorizontalPane" class="block">
+        <h3>Element</h3>
+        <button onclick="elementInHorizontalPaneObserver.destroy()">Destroy</button>
+        <button onclick="elementInHorizontalPaneObserver.activate()">Activate</button>
+      </div>
       <div class="dummyContent"></div>
     </div>
 
@@ -121,6 +133,18 @@
       })
 
       var elementInBodyObserver = ElementObserver(document.getElementById('elementInBody'), {
+        onEnter: onEnter,
+        onExit: onExit
+      })
+
+      var elementInVerticalPaneObserver = ElementObserver(document.getElementById('elementInVerticalPane'), {
+        container: document.getElementById('verticalPane'),
+        onEnter: onEnter,
+        onExit: onExit
+      })
+
+      var elementInHorizontalPaneObserver = ElementObserver(document.getElementById('elementInHorizontalPane'), {
+        container: document.getElementById('horizontalPane'),
         onEnter: onEnter,
         onExit: onExit
       })

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,14 +19,16 @@ export default [
     output: {
       format: 'umd',
       name: 'viewprt',
-      file: 'dist/viewprt.umd.js'
+      file: 'dist/viewprt.umd.js',
+      sourcemap: true
     }
   },
   {
     ...config,
     output: {
       format: 'es',
-      file: 'dist/viewprt.m.js'
+      file: 'dist/viewprt.m.js',
+      sourcemap: true
     }
   }
 ]

--- a/src/element-observer.js
+++ b/src/element-observer.js
@@ -36,13 +36,30 @@ ElementObserver.prototype.check = function(viewportState) {
 }
 
 function isElementInViewport(element, offset, viewportState) {
-  const rect = element.getBoundingClientRect()
+  const elRect = element.getBoundingClientRect()
+
+  if (!elRect.width || !elRect.height) return false
+
+  let topBound, bottomBound, leftBound, rightBound
+  const viewportElement = viewportState.viewportElement
+  if (viewportElement === window) {
+    topBound = viewportState.height
+    bottomBound = 0
+    leftBound = viewportState.width
+    rightBound = 0
+  } else {
+    const scrollElRect = viewportElement.getBoundingClientRect()
+    topBound = scrollElRect.bottom
+    bottomBound = scrollElRect.top
+    leftBound = scrollElRect.right
+    rightBound = scrollElRect.left
+  }
+
   return (
-    !!(rect.width && rect.height) &&
-    rect.top < viewportState.height + offset &&
-    rect.bottom > 0 - offset &&
-    rect.left < viewportState.width + offset &&
-    rect.right > 0 - offset
+    elRect.top < topBound + offset &&
+    elRect.bottom > bottomBound - offset &&
+    elRect.left < leftBound + offset &&
+    elRect.right > rightBound - offset
   )
 }
 

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -62,7 +62,7 @@ Viewport.prototype = {
     else if (lastY > positionY) directionY = 'up'
     else directionY = 'none'
 
-    return { width, height, positionX, positionY, directionX, directionY }
+    return { width, height, positionX, positionY, directionX, directionY, viewportElement: element }
   },
 
   destroy() {

--- a/test/index.js
+++ b/test/index.js
@@ -461,6 +461,44 @@ describe('viewprt', () => {
       )
     })
 
+    it('triggers on non-window containers', async () => {
+      assert.ok(
+        await page.evaluate(() => {
+          const container = document.createElement('div')
+          container.style.height = '100px'
+          container.style.width = '100px'
+          container.style.overflow = 'auto'
+          document.body.appendChild(container)
+
+          const spacer = document.createElement('div')
+          spacer.style.height = '200px'
+          container.appendChild(spacer)
+
+          const element = document.createElement('div')
+          element.style.height = '10px'
+          element.style.width = '10px'
+          container.appendChild(element)
+
+          return new Promise(resolve => {
+            let entered, exited
+            ElementObserver(element, {
+              container,
+              onEnter() {
+                entered = true
+              },
+              onExit() {
+                exited = true
+                entered && exited && resolve(1)
+              }
+            })
+
+            container.scrollTop = 200
+            setTimeout(() => (container.scrollTop = 0), 65)
+          })
+        })
+      )
+    })
+
     it('should trigger onEnter multiple times without an onExit callback', async () => {
       assert.ok(
         await page.evaluate(pageHeight => {


### PR DESCRIPTION
When observing an element in a scrollable div,  the bounds being checked were relative to the window instead of the div.