### PR TITLE
[bugfix] Element observed in scrolling div should also trigger when scrolling window

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -34,11 +34,16 @@
         <button onclick="horizontalPanePosObserver.destroy()">Destroy</button>
         <button onclick="horizontalPanePosObserver.activate()">Activate</button>
       </h3>
-      <div class="dummyContent"></div>
-      <div id="elementInHorizontalPane" class="block">
+      <div id="elementInHorizontalPane1" class="block">
         <h3>Element</h3>
-        <button onclick="elementInHorizontalPaneObserver.destroy()">Destroy</button>
-        <button onclick="elementInHorizontalPaneObserver.activate()">Activate</button>
+        <button onclick="elementInHorizontalPaneObserver1.destroy()">Destroy</button>
+        <button onclick="elementInHorizontalPaneObserver1.activate()">Activate</button>
+      </div>
+      <div class="dummyContent"></div>
+      <div id="elementInHorizontalPane2" class="block">
+        <h3>Element</h3>
+        <button onclick="elementInHorizontalPaneObserver2.destroy()">Destroy</button>
+        <button onclick="elementInHorizontalPaneObserver2.activate()">Activate</button>
       </div>
       <div class="dummyContent"></div>
     </div>
@@ -143,7 +148,13 @@
         onExit: onExit
       })
 
-      var elementInHorizontalPaneObserver = ElementObserver(document.getElementById('elementInHorizontalPane'), {
+      var elementInHorizontalPaneObserver1 = ElementObserver(document.getElementById('elementInHorizontalPane1'), {
+        container: document.getElementById('horizontalPane'),
+        onEnter: onEnter,
+        onExit: onExit
+      })
+
+      var elementInHorizontalPaneObserver2 = ElementObserver(document.getElementById('elementInHorizontalPane2'), {
         container: document.getElementById('horizontalPane'),
         onEnter: onEnter,
         onExit: onExit

--- a/src/element-observer.js
+++ b/src/element-observer.js
@@ -42,12 +42,25 @@ function isElementInViewport(element, offset, viewportState) {
 
   let topBound, bottomBound, leftBound, rightBound
   const viewportElement = viewportState.viewportElement
+  const windowWidth = window.innerWidth
+  const windowHeight = window.innerHeight
+  const windowTopBound = windowHeight
+  const windowLeftBound = windowWidth
+  const windowRightBound = 0
+  const windowBottomBound = 0
+
   if (viewportElement === window) {
-    topBound = viewportState.height
-    bottomBound = 0
-    leftBound = viewportState.width
-    rightBound = 0
+    topBound = windowTopBound
+    bottomBound = windowBottomBound
+    leftBound = windowLeftBound
+    rightBound = windowRightBound
   } else {
+    const isInWindow =
+      elRect.top < windowTopBound &&
+      elRect.bottom > windowBottomBound &&
+      elRect.left < windowLeftBound &&
+      elRect.right > windowRightBound
+    if (!isInWindow) return false
     const scrollElRect = viewportElement.getBoundingClientRect()
     topBound = scrollElRect.bottom
     bottomBound = scrollElRect.top

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -26,7 +26,7 @@ export default function Viewport(container) {
     }
   })
 
-  document.addEventListener('scroll', handler, true)
+  window.addEventListener('scroll', handler, true)
   window.addEventListener('resize', handler, true)
 
   if (window.MutationObserver) {
@@ -66,9 +66,9 @@ Viewport.prototype = {
   },
 
   destroy() {
-    const { element, handler, mutationObserver } = this
-    element.removeEventListener('scroll', handler)
-    element.removeEventListener('resize', handler)
+    const { handler, mutationObserver } = this
+    window.removeEventListener('scroll', handler)
+    window.removeEventListener('resize', handler)
     if (mutationObserver) mutationObserver.disconnect()
   }
 }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -8,7 +8,7 @@ export default function Viewport(container) {
   this.observers = []
   this.lastX = 0
   this.lastY = 0
-  const element = (this.element = container === document.body ? window : container)
+  this.element = container === document.body ? window : container
 
   let scheduled = false
   const throttle = window.requestAnimationFrame || (callback => setTimeout(callback, 1000 / 60))
@@ -26,13 +26,13 @@ export default function Viewport(container) {
     }
   })
 
-  element.addEventListener('scroll', handler)
-  element.addEventListener('resize', handler)
+  document.addEventListener('scroll', handler, true)
+  window.addEventListener('resize', handler, true)
 
   if (window.MutationObserver) {
-    addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('DOMContentLoaded', () => {
       const mutationObserver = (this.mutationObserver = new MutationObserver(handler))
-      mutationObserver.observe(container, { attributes: true, childList: true, subtree: true })
+      mutationObserver.observe(document, { attributes: true, childList: true, subtree: true })
     })
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -461,7 +461,7 @@ describe('viewprt', () => {
       )
     })
 
-    it('triggers on non-window containers', async () => {
+    it('triggers on non-window containers when scrolling container', async () => {
       assert.ok(
         await page.evaluate(() => {
           const container = document.createElement('div')
@@ -496,6 +496,46 @@ describe('viewprt', () => {
             setTimeout(() => (container.scrollTop = 0), 65)
           })
         })
+      )
+    })
+
+    it('triggers on non-window containers when scrolling window', async () => {
+      assert.ok(
+        await page.evaluate(pageHeight => {
+          const spacer = document.createElement('div')
+          const spacerHeight = pageHeight * 2
+          spacer.style.height = spacerHeight + 'px'
+          document.body.appendChild(spacer)
+
+          const container = document.createElement('div')
+          const containerHeight = 100
+          container.style.height = containerHeight + 'px'
+          container.style.width = containerHeight + 'px'
+          container.style.overflow = 'auto'
+          document.body.appendChild(container)
+
+          const element = document.createElement('div')
+          element.style.height = containerHeight / 2 + 'px'
+          element.style.width = containerHeight / 2 + 'px'
+          container.appendChild(element)
+
+          return new Promise(resolve => {
+            let entered, exited
+            ElementObserver(element, {
+              container,
+              onEnter() {
+                entered = true
+              },
+              onExit() {
+                exited = true
+                entered && exited && resolve(1)
+              }
+            })
+
+            window.scrollTo(0, spacerHeight + containerHeight)
+            setTimeout(() => window.scrollTo(0, 0), 65)
+          })
+        }, pageHeight)
       )
     })
 


### PR DESCRIPTION
The solution was setting `useCapture` on `addEventListener`.  We now only need a single listener on `window` and it will fire when scrolling any children too.

This will also lead to further simplifying the code and possibly eliminating having to specify a container option all together
