### PR TITLE
Modernize & drop old browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # viewprt [![Build Status](https://travis-ci.org/gpoitch/viewprt.svg)](https://travis-ci.org/gpoitch/viewprt)
 
-A tiny, dependency-free, high performance viewport position & intersection observation tool. You can watch when elements enter & exit the viewport, or when a viewport itself reaches its bounds. Use this as a building block for things such as lazy loaders, infinite scrollers, etc.
+A tiny, dependency-free, high performance viewport position & intersection observation tool. You can watch when elements enter & exit a viewport, or when a viewport itself reaches its bounds. Use this as a building block for lazy loaders, infinite scrolling, etc.
 
-#### [Demo](https://rawgit.com/gpoitch/viewprt/master/demos/index.html)
+### [Demo / Examples 🕹](https://rawgit.com/gpoitch/viewprt/master/demos/index.html)
 
 ### Install
 
 ```
-npm install viewprt --save
+npm i viewprt -S
 ```
 
-### API
+### Usage & API
 
-Create new observers and any time its container is scrolled, resized, or mutated, the appropriate callbacks will be triggered when the condition is met.
-
+<!-- prettier-ignore-start -->
 ```js
 import {
   ElementObserver, // Use this to observe when an element enters and exits the viewport
@@ -25,23 +24,24 @@ import {
 // ElementObserver(element, options)
 const elementObserver = ElementObserver(document.getElementById('element'), {
   onEnter(element, viewport) {}, // callback when the element enters the viewport
-  onExit(element, viewport) {}, // callback when the element exits the viewport
-  offset: 0, // offset from the edge of the viewport in pixels
-  once: false // if true, observer is detroyed after first callback is triggered
+  onExit(element, viewport) {},  // callback when the element exits the viewport
+  offset: 0,                     // offset from the edges of the viewport in pixels
+  once: false                    // if true, observer is detroyed after first callback is triggered
 })
 
 // PositionObserver(options)
 const positionObserver = PositionObserver({
-  onBottom(container, viewport) {}, // callback when the viewport reaches the bottom
-  onTop(container, viewport) {}, // callback when the viewport reaches the top
-  onLeft(container, viewport) {}, // callback when the viewport reaches the left
-  onRight(container, viewport) {}, // callback when the viewport reaches the right
+  onBottom(container, viewport) {},    // callback when the viewport reaches the bottom
+  onTop(container, viewport) {},       // callback when the viewport reaches the top
+  onLeft(container, viewport) {},      // callback when the viewport reaches the left
+  onRight(container, viewport) {},     // callback when the viewport reaches the right
   onMaximized(container, viewport) {}, // callback when the viewport and container are the same size
-  container: document.body, // the viewport element to observe the position of
-  offset: 0, // offset from the edge of the viewport in pixels
-  once: false // if true, observer is detroyed after first callback is triggered
+  container: document.body,            // the viewport element to observe the position of
+  offset: 0,                           // offset from the edges of the viewport in pixels
+  once: false                          // if true, observer is detroyed after first callback is triggered
 })
 ```
+<!-- prettier-ignore-end -->
 
 The `viewport` argument in callbacks is an object containing the current state of the viewport e.g.:
 
@@ -69,4 +69,4 @@ elementObserver.activate()
 ### Browser support
 
 Chrome, Firefox, Edge, IE 11+, Safari 8+  
-(requestAnimationFrame, Map, MutationObserver)
+(requestAnimationFrame, MutationObserver, Map)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ import { PositionObserver, ElementObserver } from 'viewprt'
 // Observe when an element enters and exits the viewport:
 const elementObserver = ElementObserver(document.getElementById('element'), {
   // options (defaults)
-  container: document.body, // the viewport container element
   offset: 0, // offset from the edge of the viewport in pixels
   once: false, // if true, observer is detroyed after first callback is triggered
   onEnter(element, viewportState) {}, // callback when the element enters the viewport

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # viewprt [![Build Status](https://travis-ci.org/gpoitch/viewprt.svg)](https://travis-ci.org/gpoitch/viewprt)
 
-A tiny, high performance viewport position & intersection observation tool. You can watch when elements enter & exit the viewport, or when a viewport itself is at the bottom, top, left or right. Use this as a building block for things such as lazy loaders, infinite scrollers, etc.
+A tiny, dependency-free, high performance viewport position & intersection observation tool. You can watch when elements enter & exit the viewport, or when a viewport itself reaches its bounds. Use this as a building block for things such as lazy loaders, infinite scrollers, etc.
 
 #### [Demo](https://rawgit.com/gpoitch/viewprt/master/demos/index.html)
 
 ### Install
 
-```bash
+```
 npm install viewprt --save
 ```
 
@@ -15,32 +15,37 @@ npm install viewprt --save
 Create new observers and any time its container is scrolled, resized, or mutated, the appropriate callbacks will be triggered when the condition is met.
 
 ```js
-import { PositionObserver, ElementObserver } from 'viewprt'
+import {
+  ElementObserver, // Use this to observe when an element enters and exits the viewport
+  PositionObserver // Use this to observe when a viewport reaches its bounds
+} from 'viewprt'
 
-// Observe when an element enters and exits the viewport:
+// All options are optional. The defaults are shown below.
+
+// ElementObserver(element, options)
 const elementObserver = ElementObserver(document.getElementById('element'), {
-  // options (defaults)
-  offset: 0, // offset from the edge of the viewport in pixels
-  once: false, // if true, observer is detroyed after first callback is triggered
-  onEnter(element, viewportState) {}, // callback when the element enters the viewport
-  onExit(element, viewportState) {} // callback when the element exits the viewport
+  onEnter(element, viewport) {}, // callback when the element enters the viewport
+  onExit(element, viewport) {},  // callback when the element exits the viewport
+  offset: 0,                     // offset from the edge of the viewport in pixels
+  once: false                    // if true, observer is detroyed after first callback is triggered
 })
 
-// Observe when the viewport reaches its bounds:
+// PositionObserver(options)
 const positionObserver = PositionObserver({
-  // options (defaults)
-  container: document.body, // the viewport container element
-  offset: 0, // offset from the edge of the viewport in pixels
-  once: false, // if true, observer is detroyed after first callback is triggered
-  onBottom(container, viewportState) {}, // callback when the viewport reaches the bottom
-  onTop(container, viewportState) {}, // callback when the viewport reaches the top
-  onLeft(container, viewportState) {}, // callback when the viewport reaches the left
-  onRight(container, viewportState) {}, // callback when the viewport reaches the right
-  onMaximized(container, viewportState) {} // callback when the viewport and container are the same size
+  onBottom(container, viewport) {},   // callback when the viewport reaches the bottom
+  onTop(container, viewport) {},      // callback when the viewport reaches the top
+  onLeft(container, viewport) {},     // callback when the viewport reaches the left
+  onRight(container, viewport) {},    // callback when the viewport reaches the right
+  onMaximized(container, viewport) {} // callback when the viewport and container are the same size,
+  container: document.body,           // the viewport element to observe the position of
+  offset: 0,                          // offset from the edge of the viewport in pixels
+  once: false                         // if true, observer is detroyed after first callback is triggered
 })
+```
 
-// The `viewportState` is an object containing information like:
-/*
+The `viewport` argument in callbacks is an object containing the current state of the viewport e.g.:
+
+```js
 {
   width: 1024,
   height: 768,
@@ -49,8 +54,9 @@ const positionObserver = PositionObserver({
   directionY: "down",
   directionX: "none"
 }
-*/
+```
 
+```js
 // Stop observing:
 positionObserver.destroy()
 elementObserver.destroy() // This happens automatically if the element is removed from the DOM
@@ -58,16 +64,4 @@ elementObserver.destroy() // This happens automatically if the element is remove
 // Start observing again:
 positionObserver.activate()
 elementObserver.activate()
-```
-
-## Build
-
-```bash
-npm run build
-```
-
-## Test
-
-```bash
-npm test
 ```

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ import {
 // ElementObserver(element, options)
 const elementObserver = ElementObserver(document.getElementById('element'), {
   onEnter(element, viewport) {}, // callback when the element enters the viewport
-  onExit(element, viewport) {},  // callback when the element exits the viewport
-  offset: 0,                     // offset from the edge of the viewport in pixels
-  once: false                    // if true, observer is detroyed after first callback is triggered
+  onExit(element, viewport) {}, // callback when the element exits the viewport
+  offset: 0, // offset from the edge of the viewport in pixels
+  once: false // if true, observer is detroyed after first callback is triggered
 })
 
 // PositionObserver(options)
 const positionObserver = PositionObserver({
-  onBottom(container, viewport) {},   // callback when the viewport reaches the bottom
-  onTop(container, viewport) {},      // callback when the viewport reaches the top
-  onLeft(container, viewport) {},     // callback when the viewport reaches the left
-  onRight(container, viewport) {},    // callback when the viewport reaches the right
-  onMaximized(container, viewport) {} // callback when the viewport and container are the same size,
-  container: document.body,           // the viewport element to observe the position of
-  offset: 0,                          // offset from the edge of the viewport in pixels
-  once: false                         // if true, observer is detroyed after first callback is triggered
+  onBottom(container, viewport) {}, // callback when the viewport reaches the bottom
+  onTop(container, viewport) {}, // callback when the viewport reaches the top
+  onLeft(container, viewport) {}, // callback when the viewport reaches the left
+  onRight(container, viewport) {}, // callback when the viewport reaches the right
+  onMaximized(container, viewport) {}, // callback when the viewport and container are the same size
+  container: document.body, // the viewport element to observe the position of
+  offset: 0, // offset from the edge of the viewport in pixels
+  once: false // if true, observer is detroyed after first callback is triggered
 })
 ```
 
@@ -65,3 +65,8 @@ elementObserver.destroy() // This happens automatically if the element is remove
 positionObserver.activate()
 elementObserver.activate()
 ```
+
+### Browser support
+
+Chrome, Firefox, Edge, IE 11+, Safari 8+  
+(requestAnimationFrame, Map, MutationObserver)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,105 +5,109 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-      "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.44"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0.tgz",
+      "integrity": "sha512-/BM2vupkpbZXq22l1ALO7MqXJZH2k8bKVv8Y+pABFnzWdztDB/ZLveP5At21vLz5c2YtSE6p7j2FZEsqafMz5Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.44",
+        "@babel/types": "^7.0.0",
         "jsesc": "^2.5.1",
-        "lodash": "^4.2.0",
+        "lodash": "^4.17.10",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0.tgz",
+      "integrity": "sha512-Zo+LGvfYp4rMtz84BLF3bavFTdf8y4rJtMPTe2J+rxYmnDOIeH8le++VFI/pRJU+rQhjqiXxE4LMaIau28Tv1Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.44",
-        "@babel/template": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44"
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.44"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.44"
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-      "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^4.0.0"
       }
     },
+    "@babel/parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0.tgz",
+      "integrity": "sha512-RgJhNdRinpO8zibnoHbzTTexNs4c8ROkXFBanNDZTLHjwbdLk8J5cJSKulx/bycWTLYmKVNCkxRtVCoJnqPk+g==",
+      "dev": true
+    },
     "@babel/template": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0.tgz",
+      "integrity": "sha512-VLQZik/G5mjYJ6u19U3W2u7eM+rA/NGzH+GtHDFFkLTKLW66OasFrxZ/yK7hkyQcswrmvugFyZpDFRW0DjcjCw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "lodash": "^4.2.0"
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/types": "^7.0.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0.tgz",
+      "integrity": "sha512-ka/lwaonJZTlJyn97C4g5FYjPOx+Oxd3ab05hbDr1Mx9aP1FclJ+SUHyLx3Tx40sGmOVJApDxE6puJhd3ld2kw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/generator": "7.0.0-beta.44",
-        "@babel/helper-function-name": "7.0.0-beta.44",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.0.0",
+        "@babel/helper-function-name": "^7.0.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/types": "^7.0.0",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
+        "lodash": "^4.17.10"
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
+        "lodash": "^4.17.10",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -259,24 +263,18 @@
       "dev": true
     },
     "babel-eslint": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-9.0.0.tgz",
+      "integrity": "sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/traverse": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
         "eslint-scope": "3.7.1",
         "eslint-visitor-keys": "^1.0.0"
       }
-    },
-    "babylon": {
-      "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -650,26 +648,6 @@
         "text-table": "^0.2.0"
       },
       "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
         "eslint-scope": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
@@ -679,22 +657,16 @@
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
           }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz",
-      "integrity": "sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-3.0.1.tgz",
+      "integrity": "sha512-vA0TB8HCx/idHXfKHYcg9J98p0Q8nkfNwNAoP7e+ywUidn6ScaFS5iqncZAHPz+/a0A/tp657ulFHFx/2JDP4Q==",
       "dev": true,
       "requires": {
-        "get-stdin": "^5.0.1"
+        "get-stdin": "^6.0.0"
       }
     },
     "eslint-config-standard": {
@@ -755,6 +727,16 @@
         "lodash": "^4.17.2"
       }
     },
+    "eslint-plugin-es": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-1.3.1.tgz",
+      "integrity": "sha512-9XcVyZiQRVeFjqHw8qHNDAZcQLqaHlOGGpeYqzYh8S4JYCWTCO3yzyen8yVmA5PratfzTRWDwCOFphtDEG+w/w==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^1.3.0",
+        "regexpp": "^2.0.0"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
@@ -795,29 +777,23 @@
       }
     },
     "eslint-plugin-node": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz",
-      "integrity": "sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz",
+      "integrity": "sha512-lfVw3TEqThwq0j2Ba/Ckn2ABdwmL5dkOgAux1rvOk6CO7A6yGyPI2+zIxN6FyNkp1X1X/BSvKOceD6mBWSj4Yw==",
       "dev": true,
       "requires": {
-        "ignore": "^3.3.6",
+        "eslint-plugin-es": "^1.3.1",
+        "eslint-utils": "^1.3.1",
+        "ignore": "^4.0.2",
         "minimatch": "^3.0.4",
-        "resolve": "^1.3.3",
-        "semver": "^5.4.1"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "3.3.10",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
-          "dev": true
-        }
+        "resolve": "^1.8.1",
+        "semver": "^5.5.0"
       }
     },
     "eslint-plugin-promise": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz",
-      "integrity": "sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-4.0.0.tgz",
+      "integrity": "sha512-3on8creJifkmNHvT425jCWSuVK0DG0Quf3H75ENZFqvHl6/s2xme8z6bfxww13XwqfELYWKxc/N3AtBXyV1hdg==",
       "dev": true
     },
     "eslint-plugin-react": {
@@ -834,9 +810,9 @@
       }
     },
     "eslint-plugin-standard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz",
-      "integrity": "sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",
+      "integrity": "sha512-OwxJkR6TQiYMmt1EsNRMe5qG3GsbjlcOhbGUBY4LtavF9DsLaTcoR+j2Tdjqi23oUwKNUqX7qcn5fPStafMdlA==",
       "dev": true
     },
     "eslint-scope": {
@@ -1090,23 +1066,23 @@
       }
     },
     "flt": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/flt/-/flt-0.4.1.tgz",
-      "integrity": "sha512-tv5JOPoQZrNVX37M+1QtaRUuollEC8Q+cGA9L5F2OstKa36RfTGUmTFdyntgghwTOO6tbkjFf6HvkWgn4uT9xQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/flt/-/flt-0.5.0.tgz",
+      "integrity": "sha512-0Tzd7Du0CwCBxgyZe4ADzn/m666HuMtdOvR6TF2i4GMe185KX8gp4nZ0CtAySCpBsNhFXAl99s8cWeMhsh4Sfg==",
       "dev": true,
       "requires": {
-        "babel-eslint": "^8.2.5",
-        "eslint": "^5.0.1",
-        "eslint-config-prettier": "^2.9.0",
+        "babel-eslint": "^9.0.0",
+        "eslint": "^5.5.0",
+        "eslint-config-prettier": "^3.0.1",
         "eslint-config-standard": "^12.0.0-alpha.0",
-        "eslint-plugin-css-modules": "^2.7.5",
-        "eslint-plugin-import": "^2.13.0",
-        "eslint-plugin-node": "^6.0.1",
-        "eslint-plugin-promise": "^3.8.0",
-        "eslint-plugin-react": "^7.10.0",
-        "eslint-plugin-standard": "^3.1.0",
+        "eslint-plugin-css-modules": "^2.8.1",
+        "eslint-plugin-import": "^2.14.0",
+        "eslint-plugin-node": "^7.0.1",
+        "eslint-plugin-promise": "^4.0.0",
+        "eslint-plugin-react": "^7.11.1",
+        "eslint-plugin-standard": "^4.0.0",
         "mocha": "^5.2.0",
-        "prettier": "^1.13.7",
+        "prettier": "^1.14.2",
         "yargs": "^12.0.1"
       }
     },
@@ -1150,9 +1126,9 @@
       "dev": true
     },
     "get-stdin": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
-      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "get-stream": {
@@ -1336,15 +1312,6 @@
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
-      }
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -1537,9 +1504,9 @@
       }
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
@@ -2351,34 +2318,6 @@
         "@babel/code-frame": "^7.0.0",
         "jest-worker": "^23.2.0",
         "terser": "^3.8.2"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
-          "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-          "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^4.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-          "dev": true
-        }
       }
     },
     "rollup-pluginutils": {
@@ -2401,9 +2340,9 @@
       }
     },
     "rxjs": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.1.tgz",
-      "integrity": "sha512-hRVfb1Mcf8rLXq1AZEjYpzBnQbO7Duveu1APXkWRTvqzhmkoQ40Pl2F9Btacx+gJCOqsMiugCGG4I2HPQgJRtA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "author": "Garth Poitras <garth22@gmail.com>",
   "license": "MIT",
   "main": "dist/viewprt.umd.js",
-  "module": "dist/viewprt.m.js",
+  "module": "dist/viewprt.esm.js",
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gpoitch/viewprt.git"
+  },
   "keywords": [
     "viewport",
     "observer",
@@ -18,24 +22,16 @@
     "lazy-load",
     "infinite-scroll"
   ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/gpoitch/viewprt.git"
-  },
   "scripts": {
     "build": "NODE_ENV=production rollup -c",
     "build-test": "NODE_ENV=test rollup -c",
-    "dev": "microbundle watch",
-    "test": "npm run clean && npm run format && npm run lint && npm run build-test && npm run test:js",
-    "format": "flt format",
-    "lint": "flt lint",
-    "test:js": "flt test",
+    "test": "npm run clean && flt format && flt lint && npm run build-test && flt test",
     "prepublish": "npm run build",
-    "clean": "rm -rf dist | rm -f .*cache",
+    "clean": "rm -rf dist & rm -f .*cache",
     "demo": "open demos/index.html"
   },
   "devDependencies": {
-    "flt": "^0.4.1",
+    "flt": "^0.5.0",
     "puppeteer": "^1.7.0",
     "rollup": "^0.65.0",
     "rollup-plugin-buble": "^0.19.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,7 +27,7 @@ export default [
     output: {
       ...baseConfig.output,
       format: 'esm',
-      file: 'dist/viewprt.m.js'
+      file: 'dist/viewprt.esm.js'
     }
   }
 ]

--- a/src/element-observer.js
+++ b/src/element-observer.js
@@ -16,10 +16,10 @@ ElementObserver.prototype = Object.create(Observer.prototype)
 ElementObserver.prototype.constructor = ElementObserver
 
 ElementObserver.prototype.check = function(viewportState) {
-  const { onEnter, onExit, element, offset, once, _didEnter } = this
+  const { container, onEnter, onExit, element, offset, once, _didEnter } = this
   if (!isElementInDOM(element)) return this.destroy()
 
-  const inViewport = isElementInViewport(element, offset, viewportState)
+  const inViewport = isElementInViewport(element, offset, viewportState, container)
   if (!_didEnter && inViewport) {
     this._didEnter = true
     if (onEnter) {
@@ -35,13 +35,12 @@ ElementObserver.prototype.check = function(viewportState) {
   }
 }
 
-function isElementInViewport(element, offset, viewportState) {
+function isElementInViewport(element, offset, viewportState, container) {
   const elRect = element.getBoundingClientRect()
 
   if (!elRect.width || !elRect.height) return false
 
   let topBound, bottomBound, leftBound, rightBound
-  const viewportElement = viewportState.viewportElement
   const windowWidth = window.innerWidth
   const windowHeight = window.innerHeight
   const windowTopBound = windowHeight
@@ -49,7 +48,7 @@ function isElementInViewport(element, offset, viewportState) {
   const windowRightBound = 0
   const windowBottomBound = 0
 
-  if (viewportElement === window) {
+  if (container === document.body) {
     topBound = windowTopBound
     bottomBound = windowBottomBound
     leftBound = windowLeftBound
@@ -61,7 +60,7 @@ function isElementInViewport(element, offset, viewportState) {
       elRect.left < windowLeftBound &&
       elRect.right > windowRightBound
     if (!isInWindow) return false
-    const scrollElRect = viewportElement.getBoundingClientRect()
+    const scrollElRect = container.getBoundingClientRect()
     topBound = scrollElRect.bottom
     bottomBound = scrollElRect.top
     leftBound = scrollElRect.right

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -8,7 +8,6 @@ export default function Viewport(container) {
   this.observers = []
   this.lastX = 0
   this.lastY = 0
-  this.element = container === document.body ? window : container
 
   let scheduled = false
   const throttle = window.requestAnimationFrame || (callback => setTimeout(callback, 1000 / 60))
@@ -26,8 +25,8 @@ export default function Viewport(container) {
     }
   })
 
-  window.addEventListener('scroll', handler, true)
-  window.addEventListener('resize', handler, true)
+  addEventListener('scroll', handler, true)
+  addEventListener('resize', handler, true)
 
   if (window.MutationObserver) {
     document.addEventListener('DOMContentLoaded', () => {
@@ -39,19 +38,19 @@ export default function Viewport(container) {
 
 Viewport.prototype = {
   getState() {
-    const { element, lastX, lastY } = this
+    const { container, lastX, lastY } = this
     let width, height, positionX, positionY, directionX, directionY
 
-    if (element === window) {
-      width = element.innerWidth
-      height = element.innerHeight
-      positionX = element.pageXOffset
-      positionY = element.pageYOffset
+    if (container === document.body) {
+      width = window.innerWidth
+      height = window.innerHeight
+      positionX = window.pageXOffset
+      positionY = window.pageYOffset
     } else {
-      width = element.offsetWidth
-      height = element.offsetHeight
-      positionX = element.scrollLeft
-      positionY = element.scrollTop
+      width = container.offsetWidth
+      height = container.offsetHeight
+      positionX = container.scrollLeft
+      positionY = container.scrollTop
     }
 
     if (lastX < positionX) directionX = 'right'
@@ -62,13 +61,13 @@ Viewport.prototype = {
     else if (lastY > positionY) directionY = 'up'
     else directionY = 'none'
 
-    return { width, height, positionX, positionY, directionX, directionY, viewportElement: element }
+    return { width, height, positionX, positionY, directionX, directionY }
   },
 
   destroy() {
     const { handler, mutationObserver } = this
-    window.removeEventListener('scroll', handler)
-    window.removeEventListener('resize', handler)
+    removeEventListener('scroll', handler)
+    removeEventListener('resize', handler)
     if (mutationObserver) mutationObserver.disconnect()
   }
 }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -1,7 +1,7 @@
 /**
  * @class `Viewport`
- * A a scrollable container containing multiple observers
- * that are checked each time the viewport is manipulated (scrolled, resized, mutated)
+ * A scrollable container containing multiple observers that
+ * are checked each time the viewport is manipulated
  */
 export default function Viewport(container) {
   this.container = container
@@ -10,11 +10,10 @@ export default function Viewport(container) {
   this.lastY = 0
 
   let scheduled = false
-  const throttle = window.requestAnimationFrame || (callback => setTimeout(callback, 1000 / 60))
   const handler = (this.handler = () => {
     if (!scheduled) {
       scheduled = true
-      throttle(() => {
+      requestAnimationFrame(() => {
         const { observers } = this
         const state = this.getState()
         for (let i = observers.length; i--; ) observers[i].check(state)
@@ -27,13 +26,10 @@ export default function Viewport(container) {
 
   addEventListener('scroll', handler, true)
   addEventListener('resize', handler, true)
-
-  if (window.MutationObserver) {
-    document.addEventListener('DOMContentLoaded', () => {
-      const mutationObserver = (this.mutationObserver = new MutationObserver(handler))
-      mutationObserver.observe(document, { attributes: true, childList: true, subtree: true })
-    })
-  }
+  addEventListener('DOMContentLoaded', () => {
+    const mutationObserver = (this.mutationObserver = new MutationObserver(handler))
+    mutationObserver.observe(document, { attributes: true, childList: true, subtree: true })
+  })
 }
 
 Viewport.prototype = {

--- a/test/index.js
+++ b/test/index.js
@@ -126,16 +126,16 @@ describe('viewprt', () => {
         ] = await page.evaluate(type => {
           const observer =
             type === 'ElementObserver' ? ElementObserver(document.createElement('div')) : PositionObserver()
-          const initialViewportCount = __viewports__.length
-          const initialObserverCount = __viewports__[0].observers.length
+          const initialViewportCount = __viewports__.size
+          const initialObserverCount = __viewports__.get(document.body).observers.length
           observer.destroy()
-          const destroyedViewportCount = __viewports__.length
+          const destroyedViewportCount = __viewports__.size
           observer.activate()
-          const reactivatedViewportCount = __viewports__.length
-          const reactivatedObserverCount = __viewports__[0].observers.length
+          const reactivatedViewportCount = __viewports__.size
+          const reactivatedObserverCount = __viewports__.get(document.body).observers.length
           observer.activate()
-          const alreadyActivatedViewportCount = __viewports__.length
-          const alreadyActivatedObserverCount = __viewports__[0].observers.length
+          const alreadyActivatedViewportCount = __viewports__.size
+          const alreadyActivatedObserverCount = __viewports__.get(document.body).observers.length
           return [
             initialViewportCount,
             initialObserverCount,
@@ -176,7 +176,11 @@ describe('viewprt', () => {
             Observer({ container })
             Observer({ container })
           }
-          return [__viewports__.length, __viewports__[0].observers.length, __viewports__[1].observers.length]
+          return [
+            __viewports__.size,
+            __viewports__.get(document.body).observers.length,
+            __viewports__.get(container).observers.length
+          ]
         }, type)
         assert.equal(viewportCount, 2)
         assert.equal(observerCount1, 3)
@@ -201,7 +205,7 @@ describe('viewprt', () => {
             PositionObserver({
               once: true,
               onBottom() {
-                setTimeout(() => resolve(__viewports__.length === 0))
+                setTimeout(() => resolve(__viewports__.size === 0))
               }
             })
             window.scrollTo(0, contentHeight)
@@ -227,7 +231,7 @@ describe('viewprt', () => {
             ElementObserver(element, {
               once: true,
               onEnter() {
-                setTimeout(() => resolve(__viewports__.length === 0))
+                setTimeout(() => resolve(__viewports__.size === 0))
               }
             })
             window.scrollTo(0, contentHeight)
@@ -599,12 +603,12 @@ describe('viewprt', () => {
 
         const results = []
         ElementObserver(element)
-        results.push(__viewports__.length)
+        results.push(__viewports__.size)
         document.body.removeChild(element)
         window.scrollTo(0, contentHeight)
         return new Promise(resolve => {
           setTimeout(() => {
-            results.push(__viewports__.length)
+            results.push(__viewports__.size)
             resolve(results)
           }, 65)
         })
@@ -620,7 +624,7 @@ describe('viewprt', () => {
           element.style.height = '10px'
 
           ElementObserver(element)
-          return __viewports__.length === 1
+          return __viewports__.size === 1
         })
       )
     })


### PR DESCRIPTION
Semi-breaking: Remove checks & fallbacks for `requestAnimationFrame` and `MutationObserver`.  Use `Map` internally.  This is breaking for IE < 11 however browser support was never mentioned and now it is.