### PR TITLE
Implement ObserverCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,31 @@ npm i viewprt -S
 import {
   ElementObserver, // Use this to observe when an element enters and exits the viewport
   PositionObserver // Use this to observe when a viewport reaches its bounds
+  ObserverCollection // Use different viewport handling
 } from 'viewprt'
 
 // All options are optional. The defaults are shown below.
 
 // ElementObserver(element, options)
 const elementObserver = ElementObserver(document.getElementById('element'), {
-  onEnter(element, viewport) {}, // callback when the element enters the viewport
-  onExit(element, viewport) {},  // callback when the element exits the viewport
-  offset: 0,                     // offset from the edges of the viewport in pixels
-  once: false                    // if true, observer is detroyed after first callback is triggered
+  onEnter(element, viewport) {},                  // callback when the element enters the viewport
+  onExit(element, viewport) {},                   // callback when the element exits the viewport
+  offset: 0,                                      // offset from the edges of the viewport in pixels
+  once: false,                                    // if true, observer is detroyed after first callback is triggered
+  observerCollection: new ObserverCollection()    // use different viewport collection for element
 })
 
 // PositionObserver(options)
 const positionObserver = PositionObserver({
-  onBottom(container, viewport) {},    // callback when the viewport reaches the bottom
-  onTop(container, viewport) {},       // callback when the viewport reaches the top
-  onLeft(container, viewport) {},      // callback when the viewport reaches the left
-  onRight(container, viewport) {},     // callback when the viewport reaches the right
-  onMaximized(container, viewport) {}, // callback when the viewport and container are the same size
-  container: document.body,            // the viewport element to observe the position of
-  offset: 0,                           // offset from the edges of the viewport in pixels
-  once: false                          // if true, observer is detroyed after first callback is triggered
+  onBottom(container, viewport) {},               // callback when the viewport reaches the bottom
+  onTop(container, viewport) {},                  // callback when the viewport reaches the top
+  onLeft(container, viewport) {},                 // callback when the viewport reaches the left
+  onRight(container, viewport) {},                // callback when the viewport reaches the right
+  onMaximized(container, viewport) {},            // callback when the viewport and container are the same size
+  container: document.body,                       // the viewport element to observe the position of
+  offset: 0,                                      // offset from the edges of the viewport in pixels
+  once: false,                                    // if true, observer is detroyed after first callback is triggered
+  observerCollection: new ObserverCollection()    // use different viewport collection for element
 })
 ```
 <!-- prettier-ignore-end -->
@@ -64,6 +67,25 @@ elementObserver.destroy() // This happens automatically if the element is remove
 // Start observing again:
 positionObserver.activate()
 elementObserver.activate()
+```
+
+#### Using custom observer collection
+
+If you need to control custom viewport for elements other that the default one, you can create new instance of `ObserverCollection`.
+
+This is useful for cases where you want to have debounced scroll and resize events on `window`.
+
+```js
+const debouncedObserverCollection = new ObserverCollection({ handleScrollResize: h => debounce(h, 300) });
+
+const elementObserver = ElementObserver(document.getElementById('element1'), {
+  observerCollection: debouncedObserverCollection
+})
+
+// Observer collection should be reused to have only one scroll and resize event on `window`
+const elementObserver = ElementObserver(document.getElementById('element2'), {
+  observerCollection: debouncedObserverCollection
+})
 ```
 
 ### Browser support

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export { default as PositionObserver } from './position-observer'
 export { default as ElementObserver } from './element-observer'
+export { ObserverCollection } from './observer'

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,9 +1,9 @@
 import Viewport from './viewport'
 
-function ObserverCollection(opts = {}) {
+export function ObserverCollection(opts = {}) {
   if (!(this instanceof ObserverCollection)) return new ObserverCollection(...arguments)
   this.viewports = new Map()
-  this.handleScrollResize = opts.handleScrollResize || (h => h)
+  this.handleScrollResize = opts.handleScrollResize
 }
 
 /**
@@ -51,8 +51,6 @@ Observer.prototype = {
     }
   }
 }
-
-export { ObserverCollection }
 
 // Internally track all viewports so we only have 1 set of event listeners per container
 const defaultObserverCollection = new ObserverCollection()

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,6 +1,6 @@
 import Viewport from './viewport'
 
-function ObserverCollection(opts) {
+function ObserverCollection(opts = {}) {
   if (!(this instanceof ObserverCollection)) return new ObserverCollection(...arguments)
   this.viewports = new Map()
   this.handleScrollResize = opts.handleScrollResize || (h => h)
@@ -15,7 +15,7 @@ export default function Observer(opts) {
   this.container = opts.container || document.body
   this.once = Boolean(opts.once)
   this.observerCollection =
-    opts.observerCollection instanceof ObserverCollection ? opts.observerCollection : observerCollection
+    opts.observerCollection instanceof ObserverCollection ? opts.observerCollection : defaultObserverCollection
   return this.activate()
 }
 
@@ -55,7 +55,7 @@ Observer.prototype = {
 export { ObserverCollection }
 
 // Internally track all viewports so we only have 1 set of event listeners per container
-const observerCollection = new ObserverCollection({ handleScrollResize: h => h })
+const defaultObserverCollection = new ObserverCollection()
 
 // Expose private variable for tests
-if (process.env.NODE_ENV === 'test') window.__viewports__ = observerCollection.viewports
+if (process.env.NODE_ENV === 'test') window.__viewports__ = defaultObserverCollection.viewports

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,6 +1,7 @@
 import Viewport from './viewport'
 
 function ObserverCollection(opts) {
+  if (!(this instanceof ObserverCollection)) return new ObserverCollection(...arguments)
   this.viewports = new Map()
   this.handleScrollResize = opts.handleScrollResize || (h => h)
 }

--- a/test/index.html
+++ b/test/index.html
@@ -5,6 +5,7 @@
     <script>
       window.PositionObserver = viewprt.PositionObserver
       window.ElementObserver = viewprt.ElementObserver
+      window.ObserverCollection = viewprt.ObserverCollection
     </script>
     <style>
       body { margin:0; padding:0; }


### PR DESCRIPTION
This is PoC based on https://github.com/gpoitch/viewprt/pull/16.

Viewports are now abstracted in `ObserverCollection` which currently accepts `handleScrollResize` property as function which should modify scroll resize event handler allowing developer to modify it, e.g. use throttle or debounce.

Since implementation of this module is based on reusing same handler for all elements, if developer want’s to use one handler for specific debounced event, developer should reuse same instance of `ObserverCollection`:

```js
const debounced = ObserverCollection({ handleScrollResize: ( h ) => debounce(h, 300) });

const elementObserver1 = ElementObserver({
  ...
  observerCollection: debounced
});

const elementObserver2 = ElementObserver({
  ...
  observerCollection: debounced
});
```

This still needs proper tests and documentation, but I wanted to see if this makes any sense?