### PR TITLE
Add onFit callback to PositionObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const positionObserver = PositionObserver({
   onTop(container, viewport) {},               // callback when the viewport reaches the top
   onLeft(container, viewport) {},              // callback when the viewport reaches the left
   onRight(container, viewport) {},             // callback when the viewport reaches the right
-  onMaximized(container, viewport) {},         // callback when the viewport and container are the same size
+  onFit(container, viewport) {},               // callback when the viewport contents fit within the container without having to scroll
   container: document.body,                    // the viewport element to observe the position of
   offset: 0,                                   // offset from the edges of the viewport in pixels
   once: false,                                 // if true, observer is detroyed after first callback is triggered

--- a/demos/index.html
+++ b/demos/index.html
@@ -57,6 +57,11 @@
       </h3>
     </div>
 
+    <div id="fitPane">
+      <h3>Combo observers</h3>
+      When this pane enters, another observer is set up to check if it's contents fit without scrolling.
+    </div>
+
     <div class="dummyContent"></div>
 
     <script>
@@ -111,6 +116,10 @@
         element.style.borderColor = blue
         console.log(element.id ? element.id : element.tagName.toLowerCase(), 'Reached right', element, viewportState)
       }
+      function onFit(element, viewportState) {
+        element.style.borderColor = green
+        console.log(element.id ? element.id : element.tagName.toLowerCase(), 'Fits', element, viewportState)
+      }
       function onEnter(element, viewportState) {
         element.style.backgroundColor = green
         console.log('Entered viewport', element, viewportState)
@@ -158,6 +167,16 @@
         container: document.getElementById('horizontalPane'),
         onEnter: onEnter,
         onExit: onExit
+      })
+
+      var fitElementObserver = ElementObserver(document.getElementById('fitPane'), {
+        onEnter(element, viewportState) {
+          onEnter(element, viewportState)
+          var fitPanePosObserver = PositionObserver({
+            container: element,
+            onFit: onFit
+          })
+        }
       })
     </script>
   </body>

--- a/demos/style.css
+++ b/demos/style.css
@@ -11,7 +11,8 @@ h3 {
 }
 
 #verticalPane,
-#horizontalPane {
+#horizontalPane,
+#fitPane {
   height: 15em;
   padding: 1em;
   margin: 1em 0;

--- a/src/position-observer.js
+++ b/src/position-observer.js
@@ -7,12 +7,13 @@ export function PositionObserver(opts = {}) {
   this.onBottom = opts.onBottom
   this.onLeft = opts.onLeft
   this.onRight = opts.onRight
-  this.onMaximized = opts.onMaximized
+  this.onFit = opts.onFit
 
   this._wasTop = true
   this._wasBottom = false
   this._wasLeft = true
   this._wasRight = false
+  this._wasFit = false
 
   const viewport = Observer.call(this, opts)
   this.check(viewport.getState())
@@ -27,11 +28,12 @@ PositionObserver.prototype.check = function(viewportState) {
     onBottom,
     onLeft,
     onRight,
-    onMaximized,
+    onFit,
     _wasTop,
     _wasBottom,
     _wasLeft,
     _wasRight,
+    _wasFit,
     container,
     offset,
     once
@@ -43,6 +45,7 @@ PositionObserver.prototype.check = function(viewportState) {
   const atBottom = scrollHeight > height && height + positionY + offset >= scrollHeight
   const atLeft = positionX - offset <= 0
   const atRight = scrollWidth > width && width + positionX + offset >= scrollWidth
+  const fits = scrollHeight <= height && scrollWidth <= width
 
   let untriggered = false
 
@@ -50,7 +53,7 @@ PositionObserver.prototype.check = function(viewportState) {
   else if (onTop && !_wasTop && atTop) onTop.call(this, container, viewportState)
   else if (onRight && !_wasRight && atRight) onRight.call(this, container, viewportState)
   else if (onLeft && !_wasLeft && atLeft) onLeft.call(this, container, viewportState)
-  else if (onMaximized && scrollHeight === height) onMaximized.call(this, container, viewportState)
+  else if (onFit && !_wasFit && fits) onFit.call(this, container, viewportState)
   else untriggered = true
 
   if (once && !untriggered) this.destroy()
@@ -59,4 +62,5 @@ PositionObserver.prototype.check = function(viewportState) {
   this._wasBottom = atBottom
   this._wasLeft = atLeft
   this._wasRight = atRight
+  this._wasFit = fits
 }

--- a/test/index.js
+++ b/test/index.js
@@ -370,7 +370,7 @@ describe('viewprt', () => {
       )
     })
 
-    it('triggers onMaximized but not other callbacks when content and container are same size', async () => {
+    it('triggers onFit but not other callbacks when content fits within container', async () => {
       assert(
         await page.evaluate(pageHeight => {
           const content = document.createElement('div')
@@ -380,7 +380,7 @@ describe('viewprt', () => {
 
           return new Promise(resolve => {
             PositionObserver({
-              onMaximized() {
+              onFit() {
                 resolve(1)
               },
               onTop() {
@@ -398,6 +398,36 @@ describe('viewprt', () => {
             })
             window.scrollTo(0, contentHeight)
             content.style.height = pageHeight + 'px'
+          })
+        }, pageHeight)
+      )
+    })
+
+    it('triggers onFit when content initially fits within container', async () => {
+      assert(
+        await page.evaluate(pageHeight => {
+          const content = document.createElement('div')
+          content.style.height = pageHeight + 'px'
+          document.body.appendChild(content)
+
+          return new Promise(resolve => {
+            PositionObserver({
+              onFit() {
+                resolve(1)
+              },
+              onTop() {
+                resolve(0)
+              },
+              onBottom() {
+                resolve(0)
+              },
+              onLeft() {
+                resolve(0)
+              },
+              onRight() {
+                resolve(0)
+              }
+            })
           })
         }, pageHeight)
       )


### PR DESCRIPTION
Adds `onFit` to `PositionObserver` and removes `onMaximized` (Breaking change).

This is triggered if the entire contents of the container fits within the viewport without having to scroll. 

For example, if you have an infinite scroll scenario on a big screen and the initial content fits without having to scroll, you'd need a way to trigger a load of the next page.

onMaximized was initially added to support this use case. However, that only triggered if the viewport/container were the same exact size, and didn't support if it was smaller and didn't support horizontal cases. Hence the rename.  There is sufficient info in the callback's params if anyone needs to actually check if it is exactly maximized.