### PR TITLE
Add `MutationObserver` if DOM is already loaded

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -27,12 +27,20 @@ export function Viewport(container, observerCollection) {
   const customHandleScrollResize = observerCollection.handleScrollResize
   const handler = (this.handler = customHandleScrollResize ? customHandleScrollResize(_handler) : _handler)
 
-  addEventListener('scroll', handler, true)
-  addEventListener('resize', handler, true)
-  addEventListener('DOMContentLoaded', () => {
+  const mutationObserverCallback = () => {
     const mutationObserver = (this.mutationObserver = new MutationObserver(_handler))
     mutationObserver.observe(document, { attributes: true, childList: true, subtree: true })
-  })
+  }
+
+  addEventListener('scroll', handler, true)
+  addEventListener('resize', handler, true)
+
+  const documentReadyState = document.readyState
+  if (documentReadyState === 'complete' || documentReadyState === 'interactive') {
+    mutationObserverCallback()
+  } else {
+    addEventListener('DOMContentLoaded', mutationObserverCallback)
+  }
 }
 
 Viewport.prototype = {

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -27,7 +27,7 @@ export function Viewport(container, observerCollection) {
   const customHandleScrollResize = observerCollection.handleScrollResize
   const handler = (this.handler = customHandleScrollResize ? customHandleScrollResize(_handler) : _handler)
 
-  const mutationObserverCallback = () => {
+  const createMutationObserver = () => {
     const mutationObserver = (this.mutationObserver = new MutationObserver(_handler))
     mutationObserver.observe(document, { attributes: true, childList: true, subtree: true })
   }
@@ -35,11 +35,10 @@ export function Viewport(container, observerCollection) {
   addEventListener('scroll', handler, true)
   addEventListener('resize', handler, true)
 
-  const documentReadyState = document.readyState
-  if (documentReadyState === 'complete' || documentReadyState === 'interactive') {
-    mutationObserverCallback()
+  if (document.readyState !== 'loading') {
+    createMutationObserver()
   } else {
-    addEventListener('DOMContentLoaded', mutationObserverCallback)
+    addEventListener('DOMContentLoaded', createMutationObserver)
   }
 }
 


### PR DESCRIPTION
Currently, `MutationObserver` is activated only if `DOMContentLoaded` event fires, but if you load viewprt after DOM is ready, event won’t fire and mutations are not observed. Changes in this PR use `readyState` values which correspond to state after DOM is loaded.

References for implementation:

* https://github.com/jonathantneal/document-promises/blob/master/document-promises.js#L18
* https://github.com/bendrucker/document-ready/blob/master/index.js