### PR TITLE
Gracefully recover from observer exceptions 🧸

### DIFF
--- a/src/position-observer.js
+++ b/src/position-observer.js
@@ -49,18 +49,20 @@ PositionObserver.prototype.check = function(viewportState) {
 
   let untriggered = false
 
-  if (onBottom && !_wasBottom && atBottom) onBottom.call(this, container, viewportState)
-  else if (onTop && !_wasTop && atTop) onTop.call(this, container, viewportState)
-  else if (onRight && !_wasRight && atRight) onRight.call(this, container, viewportState)
-  else if (onLeft && !_wasLeft && atLeft) onLeft.call(this, container, viewportState)
-  else if (onFit && !_wasFit && fits) onFit.call(this, container, viewportState)
-  else untriggered = true
+  try {
+    if (onBottom && !_wasBottom && atBottom) onBottom.call(this, container, viewportState)
+    else if (onTop && !_wasTop && atTop) onTop.call(this, container, viewportState)
+    else if (onRight && !_wasRight && atRight) onRight.call(this, container, viewportState)
+    else if (onLeft && !_wasLeft && atLeft) onLeft.call(this, container, viewportState)
+    else if (onFit && !_wasFit && fits) onFit.call(this, container, viewportState)
+    else untriggered = true
 
-  if (once && !untriggered) this.destroy()
-
-  this._wasTop = atTop
-  this._wasBottom = atBottom
-  this._wasLeft = atLeft
-  this._wasRight = atRight
-  this._wasFit = fits
+    if (once && !untriggered) this.destroy()
+  } finally {
+    this._wasTop = atTop
+    this._wasBottom = atBottom
+    this._wasLeft = atLeft
+    this._wasRight = atRight
+    this._wasFit = fits
+  }
 }

--- a/src/viewport.js
+++ b/src/viewport.js
@@ -16,10 +16,14 @@ export function Viewport(container, observerCollection) {
       requestAnimationFrame(() => {
         const { observers } = this
         const state = this.getState()
-        for (let i = observers.length; i--; ) observers[i].check(state)
-        this.lastX = state.positionX
-        this.lastY = state.positionY
-        scheduled = false
+
+        try {
+          for (let i = observers.length; i--; ) observers[i].check(state)
+        } finally {
+          this.lastX = state.positionX
+          this.lastY = state.positionY
+          scheduled = false
+        }
       })
     }
   }


### PR DESCRIPTION
Previously, when an exception was thrown no further updates would be able to get scheduled. This PR, adds a try/finally to ensure that the internal state is cleaned up correctly even when an exception gets thrown.