### PR TITLE
[WIP] Add enter/exit option to offsets

### DIFF
--- a/src/element-observer.js
+++ b/src/element-observer.js
@@ -16,9 +16,22 @@ ElementObserver.prototype = Object.create(Observer.prototype)
 ElementObserver.prototype.constructor = ElementObserver
 
 ElementObserver.prototype.check = function (viewportState) {
-  const { container, onEnter, onExit, element, offsetX, offsetY, once, _didEnter } = this
+  const {
+    container,
+    onEnter,
+    onExit,
+    element,
+    offsetXEnter,
+    offsetXExit,
+    offsetYEnter,
+    offsetYExit,
+    once,
+    _didEnter
+  } = this
   if (!isElementInDOM(element)) return this.destroy()
 
+  const offsetX = _didEnter ? offsetXExit : offsetXEnter
+  const offsetY = _didEnter ? offsetYExit : offsetYEnter
   const inViewport = isElementInViewport(element, offsetX, offsetY, viewportState, container)
   if (!_didEnter && inViewport) {
     this._didEnter = true

--- a/src/observer.js
+++ b/src/observer.js
@@ -5,9 +5,17 @@ import { Viewport } from './viewport'
  * Base class - each type of observer implements these options/methods
  */
 export function Observer(opts) {
-  const offset = ~~opts.offset || 0
-  this.offsetX = opts.offsetX != null ? ~~opts.offsetX : offset
-  this.offsetY = opts.offsetY != null ? ~~opts.offsetY : offset
+  const { offset, offsetX, offsetY } = opts
+  const offsetIsObject = isObject(offset)
+  const offsetXIsObject = isObject(offsetX)
+  const offsetYIsObject = isObject(offsetY)
+  const offsetEnter = ~~(offsetIsObject ? offset.enter : offset) || 0
+  const offsetExit = ~~(offsetIsObject ? offset.exit : offset) || 0
+  this.offsetXEnter = offsetX == null ? offsetEnter : ~~(offsetXIsObject ? offsetX.enter : offsetX)
+  this.offsetXExit = offsetX == null ? offsetExit : ~~(offsetXIsObject ? offsetX.exit : offsetX)
+  this.offsetYEnter = offsetY == null ? offsetEnter : ~~(offsetYIsObject ? offsetY.enter : offsetY)
+  this.offsetYExit = offsetY == null ? offsetExit : ~~(offsetYIsObject ? offsetY.exit : offsetY)
+
   this.container = opts.container || document.body
   this.once = !!opts.once
   this.observerCollection = opts.observerCollection || defaultObserverCollection
@@ -46,6 +54,10 @@ Observer.prototype = {
       }
     }
   }
+}
+
+function isObject(input) {
+  return input != null && typeof input === 'object'
 }
 
 /**

--- a/src/position-observer.js
+++ b/src/position-observer.js
@@ -35,17 +35,20 @@ PositionObserver.prototype.check = function (viewportState) {
     _wasRight,
     _wasFit,
     container,
-    offsetX,
-    offsetY,
+    offsetXEnter,
+    offsetXExit,
+    offsetYEnter,
+    offsetYExit,
     once
   } = this
   const { scrollHeight, scrollWidth } = container
   const { width, height, positionX, positionY } = viewportState
 
-  const atTop = positionY - offsetY <= 0
-  const atBottom = scrollHeight > height && height + positionY + offsetY >= scrollHeight
-  const atLeft = positionX - offsetX <= 0
-  const atRight = scrollWidth > width && width + positionX + offsetX >= scrollWidth
+  const atTop = positionY - (_wasTop ? offsetYExit : offsetYEnter) <= 0
+  const atBottom =
+    scrollHeight > height && height + positionY + (_wasBottom ? offsetYExit : offsetYEnter) >= scrollHeight
+  const atLeft = positionX - (_wasLeft ? offsetXExit : offsetXEnter) <= 0
+  const atRight = scrollWidth > width && width + positionX + (_wasRight ? offsetXExit : offsetXEnter) >= scrollWidth
   const fits = scrollHeight <= height && scrollWidth <= width
 
   let untriggered = false

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,37 +53,36 @@ describe('viewprt', () => {
 
   describe('options', () => {
     it('offset option', async () => {
-      async function testOption(input, expected) {
-        const posObserver = await page.evaluate((offset) => PositionObserver({ offset }), input)
-        assert.equal(posObserver.offsetX, expected)
-        assert.equal(posObserver.offsetY, expected)
-        const elObserver = await page.evaluate((offset) => ElementObserver(null, { offset }), input)
-        assert.equal(elObserver.offsetX, expected)
-        assert.equal(elObserver.offsetY, expected)
+      async function testOption(options, expected) {
+        const posObserver = await page.evaluate((options) => PositionObserver(options), options)
+        assert.deepEqual(
+          [posObserver.offsetXEnter, posObserver.offsetXExit, posObserver.offsetYEnter, posObserver.offsetYExit],
+          expected
+        )
+        const elObserver = await page.evaluate((options) => ElementObserver(null, options), options)
+        assert.deepEqual(
+          [elObserver.offsetXEnter, elObserver.offsetXExit, elObserver.offsetYEnter, elObserver.offsetYExit],
+          expected
+        )
       }
 
-      await testOption(undefined, 0)
-      await testOption(null, 0)
-      await testOption(100, 100)
-      await testOption(-100, -100)
-      await testOption('100', 100)
-      await testOption('abc', 0)
-    })
+      await testOption({ offset: 100 }, [100, 100, 100, 100])
+      await testOption({ offset: -100 }, [-100, -100, -100, -100])
+      await testOption({ offset: '100' }, [100, 100, 100, 100])
+      await testOption({ offset: 'abc' }, [0, 0, 0, 0])
+      await testOption({ offset: undefined }, [0, 0, 0, 0])
+      await testOption({ offset: null }, [0, 0, 0, 0])
 
-    it('offsetX/Y option', async () => {
-      async function testOption(input, expected) {
-        const posObserver = await page.evaluate((offsetX) => PositionObserver({ offsetX }), input)
-        assert.equal(posObserver.offsetX, expected)
-        const elObserver = await page.evaluate((offsetY) => ElementObserver(null, { offsetY }), input)
-        assert.equal(elObserver.offsetY, expected)
-      }
+      await testOption({ offsetX: 100 }, [100, 100, 0, 0])
+      await testOption({ offsetY: 100 }, [0, 0, 100, 100])
+      await testOption({ offsetX: 100, offsetY: 200 }, [100, 100, 200, 200])
+      await testOption({ offset: 100, offsetY: 200 }, [100, 100, 200, 200])
 
-      await testOption(undefined, 0)
-      await testOption(null, 0)
-      await testOption(100, 100)
-      await testOption(-100, -100)
-      await testOption('100', 100)
-      await testOption('abc', 0)
+      await testOption({ offset: { enter: 100, exit: 200 } }, [100, 200, 100, 200])
+      await testOption({ offsetX: { enter: 100, exit: 200 }, offsetY: { enter: 300, exit: 400 } }, [100, 200, 300, 400])
+      await testOption({ offsetX: { enter: 100, exit: 200 }, offsetY: 500 }, [100, 200, 500, 500])
+      await testOption({ offsetX: { enter: 100, exit: 200 } }, [100, 200, 0, 0])
+      await testOption({ offset: 100, offsetX: { enter: 500 } }, [500, 0, 100, 100])
     })
 
     it('once option', async () => {


### PR DESCRIPTION
API is set up and tested.  The actual functionality may not be possible.  For example, if you set the enter to 500 and exit to 100, you have a 400px area where the onEnter/onExit callbacks would repeatedly flicker between being called.

Closes #27 