### PR TITLE
Use passive event listeners

### DIFF
--- a/src/viewport.js
+++ b/src/viewport.js
@@ -32,8 +32,9 @@ export function Viewport(container, observerCollection) {
     mutationObserver.observe(document, { attributes: true, childList: true, subtree: true })
   }
 
-  addEventListener('scroll', handler, true)
-  addEventListener('resize', handler, true)
+  const listenerOpts = { capture: true, passive: true }
+  addEventListener('scroll', handler, listenerOpts)
+  addEventListener('resize', handler, listenerOpts)
 
   if (document.readyState !== 'loading') {
     createMutationObserver()


### PR DESCRIPTION
Use the new passive option for performance.
Since capture is true, we shouldn't need a compatibility check because the options object is truthy.
