### PR TITLE
Add support for proper ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "author": "Garth Poitras <garth22@gmail.com>",
   "license": "MIT",
   "main": "dist/umd/viewprt.js",
-  "module": "dist/es/viewprt.js",
+  "module": "dist/es/viewprt.mjs",
   "exports": {
     ".": {
-      "import": "./dist/es/viewprt.js",
+      "import": "./dist/es/viewprt.mjs",
       "require": "./dist/umd/viewprt.js"
     },
     "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "license": "MIT",
   "main": "dist/umd/viewprt.js",
   "module": "dist/es/viewprt.js",
+  "exports": {
+    ".": {
+      "import": "./dist/es/viewprt.js",
+      "require": "./dist/umd/viewprt.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,33 @@
+const path = require('path')
+const { promises: fs } = require('fs')
 const buble = require('rollup-plugin-buble')
 const replace = require('rollup-plugin-replace')
 const { terser: minify } = require('rollup-plugin-terser')
 
 const ENV = process.env.NODE_ENV
+
+const writePackageType = () => {
+  return {
+    name: 'package-type',
+    async writeBundle(output) {
+      let prefix, type
+      if (output.file.includes('umd/')) {
+        prefix = 'dist/umd'
+        type = 'commonjs'
+      } else if (output.file.includes('es/')) {
+        prefix = 'dist/es'
+        type = 'module'
+      }
+      if (typeof prefix !== 'undefined') {
+        const package_ = path.join(prefix, 'package.json')
+        try {
+          await fs.unlink(package_)
+        } catch (error) {}
+        await fs.writeFile(package_, JSON.stringify({ type }), 'utf8')
+      }
+    }
+  }
+}
 
 const baseConfig = {
   input: 'src/index.js',
@@ -10,7 +35,12 @@ const baseConfig = {
     name: 'viewprt',
     sourcemap: true
   },
-  plugins: [buble(), replace({ 'process.env.NODE_ENV': JSON.stringify(ENV) }), ENV === 'production' && minify()]
+  plugins: [
+    writePackageType(),
+    buble(),
+    replace({ 'process.env.NODE_ENV': JSON.stringify(ENV) }),
+    ENV === 'production' && minify()
+  ]
 }
 
 export default [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,33 +1,8 @@
-const path = require('path')
-const { promises: fs } = require('fs')
 const buble = require('rollup-plugin-buble')
 const replace = require('rollup-plugin-replace')
 const { terser: minify } = require('rollup-plugin-terser')
 
 const ENV = process.env.NODE_ENV
-
-const writePackageType = () => {
-  return {
-    name: 'package-type',
-    async writeBundle(output) {
-      let prefix, type
-      if (output.file.includes('umd/')) {
-        prefix = 'dist/umd'
-        type = 'commonjs'
-      } else if (output.file.includes('es/')) {
-        prefix = 'dist/es'
-        type = 'module'
-      }
-      if (typeof prefix !== 'undefined') {
-        const package_ = path.join(prefix, 'package.json')
-        try {
-          await fs.unlink(package_)
-        } catch (error) {}
-        await fs.writeFile(package_, JSON.stringify({ type }), 'utf8')
-      }
-    }
-  }
-}
 
 const baseConfig = {
   input: 'src/index.js',
@@ -35,12 +10,7 @@ const baseConfig = {
     name: 'viewprt',
     sourcemap: true
   },
-  plugins: [
-    writePackageType(),
-    buble(),
-    replace({ 'process.env.NODE_ENV': JSON.stringify(ENV) }),
-    ENV === 'production' && minify()
-  ]
+  plugins: [buble(), replace({ 'process.env.NODE_ENV': JSON.stringify(ENV) }), ENV === 'production' && minify()]
 }
 
 export default [
@@ -57,7 +27,7 @@ export default [
     output: {
       ...baseConfig.output,
       format: 'esm',
-      file: 'dist/es/viewprt.js'
+      file: 'dist/es/viewprt.mjs'
     }
   }
 ]


### PR DESCRIPTION
This PR adds support for proper ES module configuration:

* `exports` field which references CommonJS and ES module
* Adjusts Rollup configuration to create additional `package.json` files with proper `type` properties

This should *probably* be breaking change as [explained in official documentation](https://nodejs.org/api/packages.html#packages_package_entry_points).